### PR TITLE
fix: address issues #19, #20, #21, #11, #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ Find your board below and download the matching firmware from [Releases](https:/
 
 | Your Board | Firmware File | Notes |
 |------------|---------------|-------|
-| **ESP32 DevKit** | `esp32-headless_firmware.bin` | Any generic ESP32 board |
-| **ESP32-WROOM-32** | `esp32-headless_firmware.bin` | Headless (serial output only) |
+| **ESP32 DevKit** | `esp32-headless_firmware.bin` | Any generic ESP32, GPIO LED status |
+| **ESP32-WROOM-32** | `esp32-headless_firmware.bin` | GPIO LED on pin 2 |
 | **NodeMCU ESP32** | `esp32-headless_firmware.bin` | Use headless firmware |
 
 ### File Types
@@ -164,7 +164,7 @@ Find your board below and download the matching firmware from [Releases](https:/
 | Freenove ESP32-S3 | ✅ Full | 2.8" IPS with SD_MMC |
 | ESP32-S3/C3 + OLED | ✅ Full | 128x64 SSD1306 I2C |
 | ESP32-S3/C3 Mini | ✅ Full | RGB LED status |
-| ESP32 Headless | ✅ Full | Serial output only |
+| ESP32 Headless | ✅ Full | GPIO LED status indicator |
 | LILYGO T-Display S3 | ❌ None | Not yet supported |
 | LILYGO T-Display V1 | ❌ None | Not yet supported |
 | ESP32-S2 boards | ❌ None | Single-core not supported |
@@ -184,7 +184,8 @@ Find your board below and download the matching firmware from [Releases](https:/
 - **Display:** TFT (ILI9341/ST7789) or OLED (SSD1306)
 - **Storage:** MicroSD card slot (select boards)
 - **Connectivity:** WiFi 802.11 b/g/n
-- **RGB LED:** Status indicator (headless boards)
+- **RGB LED:** Status indicator (S3 Mini, Headless-LED boards)
+- **GPIO LED:** Simple blink status indicator (Headless boards, pin 2)
 - **Button:** Boot button for interaction
 
 ---
@@ -222,6 +223,7 @@ Create a `config.json` file on a FAT32-formatted microSD card:
 | `worker_name` | No | `SparkMiner` | Identifier shown on pool dashboard |
 | `pool_password` | No | `x` | Pool password (usually `x`) |
 | `brightness` | No | `100` | Display brightness (0-100) |
+| `screen_timeout` | No | `0` | Screen auto-off timeout in seconds (0=never, 30, 60, 120, 300) |
 | `rotation` | No | `1` | Screen rotation (0-3) |
 | `invert_colors` | No | `false` | Invert display colors |
 | `backup_pool_url` | No | - | Failover pool hostname |
@@ -393,7 +395,7 @@ The BOOT button (closest to USB-C) provides these actions:
 | **Long press (1.5s)** | Factory reset | 3-second countdown, release to cancel |
 | **Hold at boot (5s)** | Factory reset | Alternative if UI is unresponsive |
 
-> **Note:** Buttons remain responsive during mining thanks to a dedicated FreeRTOS task.
+> **Note:** Buttons remain responsive during mining thanks to a dedicated FreeRTOS task. If screen timeout is enabled, the first button press wakes the display instead of performing its normal action.
 
 ---
 
@@ -501,7 +503,7 @@ SparkMiner uses both ESP32 cores efficiently:
 | Problem | Solution |
 |---------|----------|
 | Won't connect to WiFi | Check SSID/password, ensure 2.4GHz network (not 5GHz) |
-| Keeps disconnecting | Move closer to router, check for interference |
+| Keeps disconnecting | Check serial log for `[WIFI] Disconnected, reason: X` - WiFi power save is disabled automatically to improve stability with routers that have aggressive WPA rekey |
 | AP mode not appearing | Hold BOOT 5s at power-on, or long-press during operation |
 
 ### Display Issues

--- a/include/board_config.h
+++ b/include/board_config.h
@@ -243,6 +243,11 @@
 
     #define USE_DISPLAY 0
 
+    // GPIO LED status (simple on/off, no FastLED needed)
+    #define USE_LED_STATUS 1
+    #define GPIO_LED_PIN 2          // Onboard blue LED
+    #define GPIO_LED_ACTIVE_LOW 0   // Most boards: HIGH = on
+
     #ifndef BUTTON_PIN
         #define BUTTON_PIN 0
     #endif

--- a/platformio.ini
+++ b/platformio.ini
@@ -468,6 +468,9 @@ build_flags =
     -D USE_HARDWARE_SHA=1
     -D USE_DISPLAY=0
     -D BUTTON_PIN=0
+    ; GPIO LED status (simple on/off blink, no FastLED needed)
+    -D USE_LED_STATUS=1
+    -D GPIO_LED_PIN=2
     ; Optimization - headless can use O3
     -O3
     -funroll-loops
@@ -478,6 +481,7 @@ lib_ignore =
     OpenFontRender
     SD
     SD_MMC
+    FastLED
 
 ; ============================================================
 ; ESP32-S3 Mini (Wemos/Lolin) - Headless with RGB LED
@@ -693,6 +697,9 @@ build_flags =
     -D ESP32_HEADLESS=1
     -D USE_HARDWARE_SHA=1
     -D BUTTON_PIN=0
+    ; GPIO LED status (simple on/off blink, no FastLED needed)
+    -D USE_LED_STATUS=1
+    -D GPIO_LED_PIN=2
     ; Optimization - headless can use O3
     -O3
     -funroll-loops
@@ -703,6 +710,7 @@ lib_ignore =
     OpenFontRender
     SD
     SD_MMC
+    FastLED
 
 ; ============================================================
 ; ESP32-S3 with 2.13in E-Ink display (Only v1.1 for now)

--- a/src/config/wifi_manager.cpp
+++ b/src/config/wifi_manager.cpp
@@ -36,10 +36,12 @@ static WiFiManagerParameter* s_paramDifficulty = NULL;
 static char s_rotationHtml[1024];
 static char s_invertHtml[512];
 static char s_brightnessHtml[512];
+static char s_screenTimeoutHtml[512];
 static char s_difficultyHtml[768];
 static WiFiManagerParameter* s_paramRotation = NULL;
 static WiFiManagerParameter* s_paramTimezone = NULL;
 static WiFiManagerParameter* s_paramInvert = NULL;
+static WiFiManagerParameter* s_paramScreenTimeout = NULL;
 
 // Stats API parameters
 static WiFiManagerParameter* s_paramStatsHeader = NULL;
@@ -113,6 +115,9 @@ static void saveParamsCallback() {
     }
     if (s_paramInvert) {
         config->invertColors = (atoi(s_paramInvert->getValue()) == 1);
+    }
+    if (s_paramScreenTimeout) {
+        config->screenTimeout = atoi(s_paramScreenTimeout->getValue());
     }
 
     // Stats API
@@ -215,6 +220,23 @@ void wifi_manager_init() {
     static char s_bufBrightness[8];
     snprintf(s_bufBrightness, sizeof(s_bufBrightness), "%d", config->brightness);
     s_paramBrightness = new WiFiManagerParameter("bright", "Brightness", s_bufBrightness, 4, s_brightnessHtml);
+    // Screen Timeout dropdown
+    const int timeoutValues[] = {0, 30, 60, 120, 300};
+    const char* timeoutLabels[] = {"Never", "30 seconds", "1 minute", "2 minutes", "5 minutes"};
+    strcpy(s_screenTimeoutHtml, "<br><select name='scrn_to'>");
+    for(int i=0; i<5; i++) {
+        char opt[80];
+        sprintf(opt, "<option value='%d'%s>%s</option>",
+            timeoutValues[i],
+            (config->screenTimeout == timeoutValues[i]) ? " selected" : "",
+            timeoutLabels[i]);
+        strcat(s_screenTimeoutHtml, opt);
+    }
+    strcat(s_screenTimeoutHtml, "</select>");
+    static char s_bufScreenTimeout[8];
+    snprintf(s_bufScreenTimeout, sizeof(s_bufScreenTimeout), "%d", config->screenTimeout);
+    s_paramScreenTimeout = new WiFiManagerParameter("scrn_to", "Screen Timeout", s_bufScreenTimeout, 4, s_screenTimeoutHtml);
+
     // Difficulty dropdown (common solo mining values)
     const double diffValues[] = {0.00001, 0.0001, 0.001, 0.0014, 0.01, 0.1, 1.0};
     const char* diffLabels[] = {"0.00001 (Easiest)", "0.0001", "0.001", "0.0014 (Default)", "0.01", "0.1", "1.0 (Hardest)"};
@@ -348,13 +370,13 @@ void wifi_manager_init() {
         "button:hover{background:#ff8c00;}"
         "div{padding:5px 0;}"
         // Hide redundant text inputs for dropdown fields (dropdowns handle these)
-        "input[name='bright'],input[name='diff'],input[name='rotation'],input[name='invert'],input[name='https_stats'],input[name='tz'],input[name='stats_en']{display:none;}"
+        "input[name='bright'],input[name='scrn_to'],input[name='diff'],input[name='rotation'],input[name='invert'],input[name='https_stats'],input[name='tz'],input[name='stats_en']{display:none;}"
         "</style>"
         "<script>"
         // Sync dropdown values to hidden inputs on load and change
         "function syncDropdowns(){"
         "console.log('[SYNC] Starting dropdown sync...');"
-        "var dd=['bright','diff','rotation','tz','invert','https_stats','stats_en'];"
+        "var dd=['bright','scrn_to','diff','rotation','tz','invert','https_stats','stats_en'];"
         "dd.forEach(function(n){"
         "var sel=document.querySelector('select[name=\"'+n+'\"]');"
         "var inp=document.querySelector('input[name=\"'+n+'\"]');"
@@ -375,7 +397,7 @@ void wifi_manager_init() {
         "}"
         // Log all values before form submit
         "function logFormValues(){"
-        "var dd=['bright','diff','rotation','tz','invert','https_stats','stats_en'];"
+        "var dd=['bright','scrn_to','diff','rotation','tz','invert','https_stats','stats_en'];"
         "console.log('[SUBMIT] Form values before submit:');"
         "dd.forEach(function(n){"
         "var sel=document.querySelector('select[name=\"'+n+'\"]');"
@@ -410,6 +432,7 @@ void wifi_manager_init() {
     s_wm.addParameter(s_paramBackupPoolPassword);
 
     s_wm.addParameter(s_paramBrightness);
+    s_wm.addParameter(s_paramScreenTimeout);
     s_wm.addParameter(s_paramDifficulty);
     s_wm.addParameter(s_paramRotation);
     s_wm.addParameter(s_paramTimezone);
@@ -455,6 +478,8 @@ void wifi_manager_blocking() {
         Serial.println("[WIFI] Connected!");
         Serial.printf("[WIFI] IP: %s\n", WiFi.localIP().toString().c_str());
         strncpy(s_ipAddress, WiFi.localIP().toString().c_str(), sizeof(s_ipAddress));
+
+        WiFi.setSleep(false);  // Disable power save (prevents WPA rekey issues)
 
         // Save WiFi credentials to our config
         strncpy(config->ssid, WiFi.SSID().c_str(), MAX_SSID_LENGTH);
@@ -523,6 +548,8 @@ void wifi_manager_start() {
         if (WiFi.status() == WL_CONNECTED) {
             Serial.printf("[WIFI] Connected! IP: %s\n", WiFi.localIP().toString().c_str());
             strncpy(s_ipAddress, WiFi.localIP().toString().c_str(), sizeof(s_ipAddress));
+
+            WiFi.setSleep(false);  // Disable power save (prevents WPA rekey issues)
             
             // Configure NTP
             long gmtOffset = config->timezoneOffset * 3600L;

--- a/src/display/display.cpp
+++ b/src/display/display.cpp
@@ -99,6 +99,7 @@ static uint8_t s_currentScreen = SCREEN_MINING;
 static uint8_t s_brightness = 100;
 static uint8_t s_rotation = 1;  // Current rotation (0-3)
 static bool s_needsRedraw = true;
+static bool s_backlightOff = false;
 static display_data_t s_lastData;
 
 // ============================================================
@@ -690,9 +691,12 @@ static void drawClockScreen(const display_data_t *data) {
 
     y += 70;
 
-    // Date
+    // Date - clear area first to prevent superimposition
     char dateStr[32];
     strftime(dateStr, sizeof(dateStr), "%a, %b %d %Y", &timeinfo);
+
+    int dateW = w - 2*MARGIN;
+    s_tft.fillRect(MARGIN - 4, y, dateW + 8, 20, COLOR_BG);
 
     s_tft.setTextColor(COLOR_FG);
     s_tft.setTextSize(2);
@@ -859,8 +863,30 @@ void display_init(uint8_t rotation, uint8_t brightness) {
     Serial.println("[DISPLAY] Initialized");
 }
 
+void display_set_backlight_off() {
+    if (!s_backlightOff) {
+        setBacklight(0);
+        s_backlightOff = true;
+    }
+}
+
+void display_set_backlight_on() {
+    if (s_backlightOff) {
+        setBacklight(s_brightness);
+        s_backlightOff = false;
+        s_needsRedraw = true;
+    }
+}
+
+bool display_is_backlight_off() {
+    return s_backlightOff;
+}
+
 void display_update(const display_data_t *data) {
     if (!data) return;
+
+    // Skip rendering when backlight is off (save CPU)
+    if (s_backlightOff) return;
 
     // Check if anything changed
     bool dataChanged = (data->totalHashes != s_lastData.totalHashes) ||

--- a/src/display/display.h
+++ b/src/display/display.h
@@ -169,6 +169,22 @@ void display_show_reset_countdown(int seconds);
  */
 void display_show_reset_complete();
 
+/**
+ * Turn off display backlight (screen timeout)
+ */
+void display_set_backlight_off();
+
+/**
+ * Turn on display backlight (restore saved brightness)
+ */
+void display_set_backlight_on();
+
+/**
+ * Check if backlight is currently off
+ * @return true if backlight is off
+ */
+bool display_is_backlight_off();
+
 #else
 
 // Declarations for non-TFT builds
@@ -194,6 +210,9 @@ void display_show_ap_config(const char *ssid, const char *password, const char *
 void display_set_inverted(bool inverted);
 void display_show_reset_countdown(int seconds);
 void display_show_reset_complete();
+void display_set_backlight_off();
+void display_set_backlight_on();
+bool display_is_backlight_off();
 
 #endif // USE_DISPLAY
 

--- a/src/display/display_eink.cpp
+++ b/src/display/display_eink.cpp
@@ -546,5 +546,9 @@ void display_show_reset_complete() {
     eink_display_show_reset_complete();
 }
 
+void display_set_backlight_off() {}
+void display_set_backlight_on() {}
+bool display_is_backlight_off() { return false; }
+
 #endif // USE_EINK_DISPLAY
 

--- a/src/display/display_manager.cpp
+++ b/src/display/display_manager.cpp
@@ -129,6 +129,10 @@ void display_show_reset_complete() {
     Serial.println("[RESET] Complete");
 }
 
+void display_set_backlight_off() {}
+void display_set_backlight_on() {}
+bool display_is_backlight_off() { return false; }
+
 #else
 
 // Headless builds (no display, no LED): Serial output only
@@ -172,5 +176,9 @@ void display_show_reset_countdown(int seconds) {
 void display_show_reset_complete() {
     Serial.println("[RESET] Factory reset complete, restarting...");
 }
+
+void display_set_backlight_off() {}
+void display_set_backlight_on() {}
+bool display_is_backlight_off() { return false; }
 
 #endif

--- a/src/display/display_oled.cpp
+++ b/src/display/display_oled.cpp
@@ -497,4 +497,8 @@ void display_show_reset_complete() {
     oled_display_show_reset_complete();
 }
 
+void display_set_backlight_off() {}
+void display_set_backlight_on() {}
+bool display_is_backlight_off() { return false; }
+
 #endif // USE_OLED_DISPLAY

--- a/src/display/led_status.cpp
+++ b/src/display/led_status.cpp
@@ -9,7 +9,7 @@
 #include <board_config.h>
 #include "led_status.h"
 
-#if USE_LED_STATUS
+#if USE_LED_STATUS && defined(RGB_LED_PIN)
 
 #include <FastLED.h>
 
@@ -221,6 +221,134 @@ void led_status_toggle() {
     s_enabled = !s_enabled;
     if (!s_enabled) {
         FastLED.clear(true);
+    }
+    Serial.printf("[LED] Status feedback %s\n", s_enabled ? "enabled" : "disabled");
+}
+
+bool led_status_is_enabled() {
+    return s_enabled;
+}
+
+#elif USE_LED_STATUS && defined(GPIO_LED_PIN)
+
+// ============================================================
+// GPIO LED Mode - Simple on/off blink patterns (no FastLED)
+// ============================================================
+
+static led_status_t s_currentStatus = LED_STATUS_OFF;
+static led_status_t s_previousStatus = LED_STATUS_OFF;
+static bool s_enabled = true;
+static bool s_ledState = false;
+static uint32_t s_lastToggle = 0;
+static uint32_t s_flashStart = 0;
+
+static void gpioLedWrite(bool on) {
+    s_ledState = on;
+    #if GPIO_LED_ACTIVE_LOW
+        digitalWrite(GPIO_LED_PIN, on ? LOW : HIGH);
+    #else
+        digitalWrite(GPIO_LED_PIN, on ? HIGH : LOW);
+    #endif
+}
+
+void led_status_init() {
+    pinMode(GPIO_LED_PIN, OUTPUT);
+    gpioLedWrite(false);
+    s_currentStatus = LED_STATUS_BOOT;
+    s_enabled = true;
+    Serial.printf("[LED] GPIO status driver initialized (pin %d)\n", GPIO_LED_PIN);
+}
+
+void led_status_set(led_status_t status) {
+    if (status != s_currentStatus) {
+        s_previousStatus = s_currentStatus;
+        s_currentStatus = status;
+    }
+}
+
+led_status_t led_status_get() {
+    return s_currentStatus;
+}
+
+void led_status_share_found() {
+    s_previousStatus = s_currentStatus;
+    s_currentStatus = LED_STATUS_SHARE_FOUND;
+    s_flashStart = millis();
+    gpioLedWrite(true);
+}
+
+void led_status_block_found() {
+    s_previousStatus = s_currentStatus;
+    s_currentStatus = LED_STATUS_BLOCK_FOUND;
+    s_flashStart = millis();
+    gpioLedWrite(true);
+}
+
+void led_status_update() {
+    if (!s_enabled) return;
+
+    uint32_t now = millis();
+
+    // Handle temporary states
+    if (s_currentStatus == LED_STATUS_SHARE_FOUND) {
+        if (now - s_flashStart >= 500) {
+            s_currentStatus = s_previousStatus;
+        } else {
+            return;  // Keep LED on during flash
+        }
+    }
+
+    if (s_currentStatus == LED_STATUS_BLOCK_FOUND) {
+        if (now - s_flashStart >= 3000) {
+            s_currentStatus = s_previousStatus;
+        } else {
+            // Fast blink for celebration
+            if (now - s_lastToggle >= 100) {
+                gpioLedWrite(!s_ledState);
+                s_lastToggle = now;
+            }
+            return;
+        }
+    }
+
+    // Blink patterns based on status
+    uint32_t onMs, offMs;
+    switch (s_currentStatus) {
+        case LED_STATUS_OFF:
+            gpioLedWrite(false);
+            return;
+        case LED_STATUS_BOOT:
+            gpioLedWrite(true);
+            return;
+        case LED_STATUS_AP_MODE:
+        case LED_STATUS_CONNECTING:
+            onMs = 1000; offMs = 1000;  // Slow blink
+            break;
+        case LED_STATUS_MINING:
+            onMs = 200; offMs = 800;  // Fast blink
+            break;
+        case LED_STATUS_ERROR:
+            gpioLedWrite(true);  // Solid on
+            return;
+        default:
+            return;
+    }
+
+    // Toggle based on pattern
+    uint32_t elapsed = now - s_lastToggle;
+    if (s_ledState && elapsed >= onMs) {
+        gpioLedWrite(false);
+        s_lastToggle = now;
+    } else if (!s_ledState && elapsed >= offMs) {
+        gpioLedWrite(true);
+        s_lastToggle = now;
+    }
+}
+
+void led_status_toggle() {
+    s_enabled = !s_enabled;
+    if (!s_enabled) {
+        gpioLedWrite(false);
     }
     Serial.printf("[LED] Status feedback %s\n", s_enabled ? "enabled" : "disabled");
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,13 +49,23 @@ volatile bool systemReady = false;
 #if defined(BUTTON_PIN) && (USE_DISPLAY || USE_OLED_DISPLAY || USE_EINK_DISPLAY)
 OneButton button(BUTTON_PIN, true, true);  // active low, enable pullup
 
-// Single click: cycle screens
+// Single click: wake screen if off, otherwise cycle screens
 void onButtonClick() {
+    monitor_reset_activity();
+    if (display_is_backlight_off()) {
+        display_set_backlight_on();
+        return;  // First click just wakes the screen
+    }
     display_next_screen();
 }
 
 // Double click: cycle screen rotation (0->1->2->3->0)
 void onButtonDoubleClick() {
+    monitor_reset_activity();
+    if (display_is_backlight_off()) {
+        display_set_backlight_on();
+        return;
+    }
     Serial.println("[BUTTON] Double-click detected - cycling rotation");
     uint8_t newRotation = display_flip_rotation();
     // Save to NVS
@@ -67,6 +77,11 @@ void onButtonDoubleClick() {
 
 // Triple click: toggle color inversion
 void onButtonMultiClick() {
+    monitor_reset_activity();
+    if (display_is_backlight_off()) {
+        display_set_backlight_on();
+        return;
+    }
     int clicks = button.getNumberClicks();
     if (clicks == 3) {
         Serial.println("[BUTTON] Triple-click detected - toggling color theme");
@@ -80,6 +95,11 @@ void onButtonMultiClick() {
 
 // Long press: factory reset with 3-second visual countdown
 void onButtonLongPressStart() {
+    monitor_reset_activity();
+    if (display_is_backlight_off()) {
+        display_set_backlight_on();
+        return;
+    }
     Serial.println("[RESET] Long press detected - starting countdown...");
 
     // Visual countdown on display
@@ -383,6 +403,15 @@ void setup() {
     wifi_manager_init();
     Serial.println("[INIT] Starting WiFi...");
     wifi_manager_start();
+
+    // Register WiFi event handlers for diagnostics
+    WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
+        Serial.printf("[WIFI] Disconnected, reason: %d\n", info.wifi_sta_disconnected.reason);
+    }, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_DISCONNECTED);
+
+    WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
+        Serial.printf("[WIFI] Connected, channel: %d\n", WiFi.channel());
+    }, WiFiEvent_t::ARDUINO_EVENT_WIFI_STA_CONNECTED);
 
     // Initialize monitor (live stats - display already initialized)
     monitor_init();

--- a/src/stats/monitor.cpp
+++ b/src/stats/monitor.cpp
@@ -28,6 +28,7 @@ static uint32_t s_lastStatsUpdate = 0;
 static uint32_t s_lastPersistSave = 0;
 static uint32_t s_lastLedUpdate = 0;
 static uint32_t s_startTime = 0;
+static uint32_t s_lastActivityTime = 0;  // Screen timeout tracking
 static bool s_earlySaveDone = false;      // Track if we've done the early save
 static uint32_t s_lastAcceptedCount = 0;  // Track shares for first-share save
 static uint32_t s_lastLedShareCount = 0;  // Track shares for LED flash
@@ -196,9 +197,14 @@ void monitor_init() {
 
     s_startTime = millis();
     s_lastPersistSave = millis();
+    s_lastActivityTime = millis();
     s_initialized = true;
 
     Serial.println("[MONITOR] Initialized");
+}
+
+void monitor_reset_activity() {
+    s_lastActivityTime = millis();
 }
 
 void monitor_task(void *param) {
@@ -230,6 +236,16 @@ void monitor_task(void *param) {
                 // Check for touch input
                 if (display_touched()) {
                     display_handle_touch();
+                }
+
+                // Screen timeout check
+                {
+                    miner_config_t *cfg = nvs_config_get();
+                    if (cfg->screenTimeout > 0 && !display_is_backlight_off()) {
+                        if (now - s_lastActivityTime >= (uint32_t)cfg->screenTimeout * 1000) {
+                            display_set_backlight_off();
+                        }
+                    }
                 }
             #endif
 

--- a/src/stats/monitor.h
+++ b/src/stats/monitor.h
@@ -19,4 +19,10 @@ void monitor_init();
  */
 void monitor_task(void *param);
 
+/**
+ * Reset screen timeout activity timer
+ * Call on user input (button press, touch) to keep screen on
+ */
+void monitor_reset_activity();
+
 #endif // MONITOR_H

--- a/src/stratum/stratum.cpp
+++ b/src/stratum/stratum.cpp
@@ -525,9 +525,9 @@ void stratum_task(void *param) {
                 Serial.println("[WIFI] Connection lost, attempting reconnect...");
             }
 
-            // Calculate exponential backoff: 1s, 2s, 4s, 8s, 16s, 30s max
-            uint32_t backoffMs = 1000 * (1 << min(s_wifiReconnectAttempts, (uint32_t)5));
-            if (backoffMs > 30000) backoffMs = 30000;
+            // Calculate exponential backoff: 1s, 2s, 4s, 8s, 15s max
+            uint32_t backoffMs = 1000 * (1 << min(s_wifiReconnectAttempts, (uint32_t)4));
+            if (backoffMs > 15000) backoffMs = 15000;
 
             if (millis() - s_lastWifiReconnectAttempt >= backoffMs) {
                 s_wifiReconnectAttempts++;

--- a/src/stratum/stratum_types.h
+++ b/src/stratum/stratum_types.h
@@ -25,7 +25,7 @@
 typedef void (*SubmitCallback)(uint32_t sessionId, uint32_t msgId, bool accepted, const char* reason);
 
 // Fixed sizes for stratum job fields (avoid heap fragmentation from String)
-#define STRATUM_JOB_ID_LEN      16      // Job ID (usually 4-8 hex chars)
+#define STRATUM_JOB_ID_LEN      32      // Job ID (pools may send 16+ chars)
 #define STRATUM_PREVHASH_LEN    68      // Previous block hash (64 hex + null)
 #define STRATUM_COINBASE1_LEN   512     // Coinbase part 1 (variable, can be large)
 #define STRATUM_COINBASE2_LEN   256     // Coinbase part 2


### PR DESCRIPTION
## Summary
- **#19 Job ID Truncation (CRITICAL):** Increase `STRATUM_JOB_ID_LEN` from 16 to 32 — fixes 100% share rejection on pools sending 16-char job IDs
- **#20 Display Superimposed Dates:** Add `fillRect()` clear before date text on clock screen
- **#21 Display Auto-Off:** Screen timeout with configurable values (0/30s/60s/2m/5m) via config portal, button press wakes screen
- **#11 GPIO LED for Headless:** Simple on/off blink patterns using `digitalWrite()` on pin 2 — no FastLED dependency needed
- **#18 WiFi Robustness:** WiFi event logging (disconnect reason codes), disable power save mode, reduce max reconnect backoff from 30s to 15s
- **README** updated with new features (screen timeout config, GPIO LED, WiFi diagnostics)

## Test Plan
- [x] Builds pass for 6 board variants (esp32-headless, esp32-2432s028, esp32-s3-mini, esp32-c3-oled, wireless-paper, wireless-paper-headless)
- [ ] #19: Verify 16-char job IDs pass through intact on pool
- [ ] #20: Visual check — clock screen date changes cleanly without overlap
- [ ] #21: Set timeout via portal → screen turns off → button press wakes it
- [ ] #11: GPIO2 LED blinks on headless board when mining
- [ ] #18: Serial shows `[WIFI] Disconnected, reason: X` on disconnect events

Closes #19, closes #20, closes #21, closes #11, closes #18