### PR TITLE
feat: add Wemos Lolin32 + OLED board support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ python devtool.py build -b cyd-2usb
 python devtool.py flash -b cyd-2usb
 python devtool.py monitor
 
+# Wemos Lolin32 + OLED
+python devtool.py build -b wemos-lolin32-oled
+python devtool.py flash -b wemos-lolin32-oled
+
 # All-in-one: build, flash, and monitor
 python devtool.py all -b cyd-2usb
 ```
@@ -136,7 +140,8 @@ Find your board below and download the matching firmware from [Releases](https:/
 | Your Board | Firmware File | Notes |
 |------------|---------------|-------|
 | **ESP32 DevKit** | `esp32-headless_firmware.bin` | Any generic ESP32, GPIO LED status |
-| **ESP32-WROOM-32** | `esp32-headless_firmware.bin` | GPIO LED on pin 2 |
+| **ESP32-WROOM-32** | `esp32-headless_firmware.bin` | Headless — GPIO LED on pin 2 |
+| **Wemos Lolin32 + OLED** | `wemos-lolin32-oled_firmware.bin` | 128x64 SSD1306 I2C (SDA=5, SCL=4, RST=16, addr=0x3C) |
 | **NodeMCU ESP32** | `esp32-headless_firmware.bin` | Use headless firmware |
 
 ### File Types
@@ -163,6 +168,7 @@ Find your board below and download the matching firmware from [Releases](https:/
 | CYD (ESP32-2432S028) | ✅ Full | Primary target, 3 variants |
 | Freenove ESP32-S3 | ✅ Full | 2.8" IPS with SD_MMC |
 | ESP32-S3/C3 + OLED | ✅ Full | 128x64 SSD1306 I2C |
+| Wemos Lolin32 + OLED | ✅ Full | 128x64 SSD1306 I2C (SDA=GPIO5, SCL=GPIO4, RST=GPIO16, addr=0x3C) |
 | ESP32-S3/C3 Mini | ✅ Full | RGB LED status |
 | ESP32 Headless | ✅ Full | GPIO LED status indicator |
 | LILYGO T-Display S3 | ❌ None | Not yet supported |

--- a/devtool.toml
+++ b/devtool.toml
@@ -148,6 +148,14 @@ needs_boot_mode = true
 port_changes_on_reset = true
 group = "Headless (No Display)"
 
+[boards.wemos-lolin32-oled]
+name = "Wemos Lolin32 + OLED"
+env = "wemos-lolin32-oled"
+chip = "esp32"
+description = "Wemos Lolin32 with SSD1306 OLED (SDA=GPIO5, SCL=GPIO4, RST=GPIO16, addr=0x3C)"
+needs_boot_mode = false
+group = "OLED Display"
+
 # ============================================================
 # Release Settings
 # ============================================================

--- a/include/board_config.h
+++ b/include/board_config.h
@@ -354,6 +354,48 @@
     // SHA Implementation: Defined in platformio.ini (USE_HARDWARE_SHA=1)
 
 // ============================================================
+// Wemos Lolin32 + OLED Display
+// Verified wiring:
+//   SDA=GPIO5, SCL=GPIO4, RST=GPIO16, ADDR=0x3C
+// ============================================================
+#elif defined(WEMOS_LOLIN32_OLED)
+    #define BOARD_NAME "Wemos-Lolin32-OLED"
+
+    #define USE_DISPLAY 0
+    #define USE_OLED_DISPLAY 1
+
+    #ifndef OLED_WIDTH
+        #define OLED_WIDTH 128
+    #endif
+    #ifndef OLED_HEIGHT
+        #define OLED_HEIGHT 64
+    #endif
+    #ifndef OLED_SDA_PIN
+        #define OLED_SDA_PIN 5
+    #endif
+    #ifndef OLED_SCL_PIN
+        #define OLED_SCL_PIN 4
+    #endif
+    #ifndef OLED_I2C_ADDR
+        #define OLED_I2C_ADDR 0x3C
+    #endif
+    #ifndef OLED_I2C_RST
+        #define OLED_I2C_RST 16
+    #endif
+
+    #define USE_LED_STATUS 1
+    #define GPIO_LED_PIN 2
+    #define GPIO_LED_ACTIVE_LOW 0
+
+    #ifndef BUTTON_PIN
+        #define BUTTON_PIN 0
+    #endif
+    #define BUTTON_ACTIVE_LOW 1
+
+    // SHA Implementation: classic ESP32 hardware SHA peripheral
+    // Defined in platformio.ini via -D USE_HARDWARE_SHA=1
+
+// ============================================================
 // Default - Generic ESP32
 // ============================================================
 #else

--- a/platformio.ini
+++ b/platformio.ini
@@ -682,6 +682,56 @@ lib_ignore =
     FastLED
 
 ; ============================================================
+; Wemos Lolin32 + OLED (SSD1306)
+; Verified working wiring:
+;   OLED SDA  -> GPIO5
+;   OLED SCL  -> GPIO4
+;   OLED RST  -> GPIO16
+;   OLED ADDR -> 0x3C
+; ============================================================
+[env:wemos-lolin32-oled]
+board = esp32dev
+board_build.partitions = huge_app.csv
+upload_speed = 921600
+
+build_unflags = -Os
+
+build_flags =
+    ; ---- Board identity ----
+    -D WEMOS_LOLIN32_OLED=1
+    -D HAS_DISPLAY=1
+    ; ---- SHA implementation ----
+    -D USE_HARDWARE_SHA=1
+    ; ---- Display ----
+    -D USE_DISPLAY=0
+    -D USE_OLED_DISPLAY=1
+    ; ---- OLED hardware ----
+    -D OLED_WIDTH=128
+    -D OLED_HEIGHT=64
+    -D OLED_I2C_SDA=5
+    -D OLED_I2C_SCL=4
+    -D OLED_I2C_ADDR=0x3C
+    -D OLED_I2C_RST=16
+    ; ---- Status LED ----
+    -D USE_LED_STATUS=1
+    -D GPIO_LED_PIN=2
+    ; ---- Boot button ----
+    -D BUTTON_PIN=0
+    ; ---- Optimization ----
+    -O2
+
+lib_deps =
+    ${env.lib_deps}
+    olikraus/U8g2@^2.35.9
+
+lib_ignore =
+    TFT_eSPI
+    OpenFontRender
+    SD
+    SD_MMC
+    FastLED
+
+; ============================================================
 ; ESP32-S3 Headless - No display, serial only
 ; Dual-core with monochrome display and LoRa
 ; ============================================================

--- a/platformio.ini
+++ b/platformio.ini
@@ -697,9 +697,9 @@ upload_speed = 921600
 build_unflags = -Os
 
 build_flags =
+    -D AUTO_VERSION=\"v2.9.5\"
     ; ---- Board identity ----
     -D WEMOS_LOLIN32_OLED=1
-    -D HAS_DISPLAY=1
     ; ---- SHA implementation ----
     -D USE_HARDWARE_SHA=1
     ; ---- Display ----
@@ -708,9 +708,11 @@ build_flags =
     ; ---- OLED hardware ----
     -D OLED_WIDTH=128
     -D OLED_HEIGHT=64
-    -D OLED_I2C_SDA=5
-    -D OLED_I2C_SCL=4
+    ; NOTE: the OLED driver reads OLED_SDA_PIN / OLED_SCL_PIN (display_oled.cpp)
+    -D OLED_SDA_PIN=5
+    -D OLED_SCL_PIN=4
     -D OLED_I2C_ADDR=0x3C
+    ; RST is not driven (U8g2 ctor uses U8X8_PIN_NONE); kept for documentation
     -D OLED_I2C_RST=16
     ; ---- Status LED ----
     -D USE_LED_STATUS=1


### PR DESCRIPTION
Add platformio.ini env, board_config.h defines, devtool.toml entry, and README docs for the Wemos Lolin32 with SSD1306 OLED display (SDA=GPIO5, SCL=GPIO4, RST=GPIO16, addr=0x3C).