### PR TITLE
fix(wifi): explicit-credential reconnect + macOS captive-portal note (#31, #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ If no SD card config is found, SparkMiner creates a WiFi access point:
 
 1. **Connect** to WiFi network: `SparkMiner-XXXX` (password: minebitcoin)
 2. **Open browser** to `http://192.168.4.1`
+   > **macOS users:** if the captive-portal page doesn't pop up automatically and
+   > Safari/Chrome shows `ERR_INTERNET_DISCONNECTED`, type the IP address
+   > `http://192.168.4.1` directly into the address bar (not a search term). The
+   > config page is served only by the device while it has no internet access. (Issue #29)
 3. You will see the **new dark-themed portal** with full configuration options:
     - Primary & Backup Pool settings
     - Display brightness, rotation, and color inversion

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -404,6 +404,10 @@ void setup() {
     Serial.println("[INIT] Starting WiFi...");
     wifi_manager_start();
 
+    // Issue #31: backstop the explicit-credential reconnect in stratum_task by
+    // letting the SDK auto-retry association whenever the link drops.
+    WiFi.setAutoReconnect(true);
+
     // Register WiFi event handlers for diagnostics
     WiFi.onEvent([](WiFiEvent_t event, WiFiEventInfo_t info) {
         Serial.printf("[WIFI] Disconnected, reason: %d\n", info.wifi_sta_disconnected.reason);

--- a/src/stratum/stratum.cpp
+++ b/src/stratum/stratum.cpp
@@ -12,6 +12,7 @@
 #include <board_config.h>
 #include "stratum.h"
 #include "../mining/miner.h"
+#include "../config/nvs_config.h"  // WiFi credentials for explicit reconnect (Issue #31)
 
 // ============================================================ 
 // Constants
@@ -542,7 +543,17 @@ void stratum_task(void *param) {
                 s_lastWifiReconnectAttempt = millis();
                 Serial.printf("[WIFI] Reconnect attempt %lu (backoff: %lums)\n",
                               s_wifiReconnectAttempts, backoffMs);
-                WiFi.reconnect();
+                // Issue #31: WiFi.reconnect() reuses the SDK's cached credentials,
+                // which are dropped after an AP reboot / AUTH_EXPIRE, so it can fail
+                // forever and force a power cycle. Re-issue begin() with the SSID/PSK
+                // stored in NVS so reconnection survives those cases.
+                miner_config_t *cfg = nvs_config_get();
+                if (cfg && cfg->ssid[0]) {
+                    WiFi.disconnect(false);  // drop association, keep stored config
+                    WiFi.begin(cfg->ssid, cfg->wifiPassword);
+                } else {
+                    WiFi.reconnect();
+                }
             }
 
             vTaskDelay(500 / portTICK_PERIOD_MS);


### PR DESCRIPTION
## #31 — no auto-reconnect after AP/internet drop
The reconnect watchdog called `WiFi.reconnect()`, which reuses the SDK's *cached* credentials. Those are dropped after an AP reboot / AUTH_EXPIRE, so reconnection could fail forever and force a power cycle. Now it re-issues `WiFi.begin()` with the SSID/PSK stored in NVS, plus `WiFi.setAutoReconnect(true)` as a backstop.

## #29 — macOS ERR_INTERNET_DISCONNECTED on the config AP
The portal already runs WiFiManager's captive-portal DNS (why iOS works). Added a README note telling macOS users to browse to `http://192.168.4.1` directly. No code change to the setup path (avoided risking it without hardware).

## ⚠️ Testing
- [ ] On-device: mine, reboot the router/AP, confirm reconnect without power-cycling.

Closes #31. Related to #29.