### PR TITLE
feat(board): add esp32-devkit-oled target for generic ESP32 + SSD1306 (#26)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Find your board below and download the matching firmware from [Releases](https:/
 | **ESP32-WROOM-32** | `esp32-headless_firmware.bin` | Headless — GPIO LED on pin 2 |
 | **Wemos Lolin32 + OLED** | `wemos-lolin32-oled_firmware.bin` | 128x64 SSD1306 I2C (SDA=5, SCL=4, RST=16, addr=0x3C) |
 | **NodeMCU ESP32** | `esp32-headless_firmware.bin` | Use headless firmware |
+| **ESP32 DevKit + SSD1306 OLED** | `esp32-devkit-oled_firmware.bin` | 128x64 I2C OLED (SDA=GPIO21, SCL=GPIO22, addr=0x3C) |
 
 ### File Types
 

--- a/devtool.toml
+++ b/devtool.toml
@@ -130,6 +130,14 @@ needs_boot_mode = true
 port_changes_on_reset = true
 group = "OLED Display"
 
+[boards.esp32-devkit-oled]
+name = "ESP32 DevKit OLED"
+env = "esp32-devkit-oled"
+chip = "esp32"
+description = "Generic ESP32/WROOM with 128x64 SSD1306 OLED (SDA=GPIO21, SCL=GPIO22, addr=0x3C)"
+needs_boot_mode = false
+group = "OLED Display"
+
 [boards.wireless-paper]
 name = "Heltec Wireless Paper"
 env = "wireless-paper"

--- a/include/board_config.h
+++ b/include/board_config.h
@@ -396,6 +396,44 @@
     // Defined in platformio.ini via -D USE_HARDWARE_SHA=1
 
 // ============================================================
+// Generic ESP32 DevKit / WROOM with SSD1306 OLED (Issue #26)
+// Standard ESP32 I2C pins; classic Xtensa pipelined SHA (~715 KH/s)
+// ============================================================
+#elif defined(ESP32_DEVKIT_OLED)
+    #define BOARD_NAME "ESP32-DevKit-OLED"
+
+    // Use OLED display (not TFT)
+    #define USE_DISPLAY 0
+    #define USE_OLED_DISPLAY 1
+
+    // OLED configuration (128x64 SSD1306 I2C, standard ESP32 I2C pins).
+    // Guarded so platformio.ini build flags can override per-board wiring.
+    #ifndef OLED_WIDTH
+        #define OLED_WIDTH 128
+    #endif
+    #ifndef OLED_HEIGHT
+        #define OLED_HEIGHT 64
+    #endif
+    #ifndef OLED_SDA_PIN
+        #define OLED_SDA_PIN 21
+    #endif
+    #ifndef OLED_SCL_PIN
+        #define OLED_SCL_PIN 22
+    #endif
+    #ifndef OLED_I2C_ADDR
+        #define OLED_I2C_ADDR 0x3C
+    #endif
+
+    #ifndef BUTTON_PIN
+        #define BUTTON_PIN 0
+    #endif
+    #define BUTTON_ACTIVE_LOW 1
+
+    // SHA Implementation: classic ESP32 pipelined Xtensa ASM auto-selected via
+    // CONFIG_IDF_TARGET_ESP32 (USE_HARDWARE_SHA in platformio.ini is cosmetic here)
+
+
+// ============================================================
 // Default - Generic ESP32
 // ============================================================
 #else

--- a/platformio.ini
+++ b/platformio.ini
@@ -794,3 +794,46 @@ lib_ignore =
     OpenFontRender
     SD
     SD_MMC
+
+; ============================================================
+; Generic ESP32 DevKit / WROOM with SSD1306 OLED (Issue #26)
+; Classic ESP32 (Xtensa LX6) -> pipelined ASM SHA (~715 KH/s).
+; Wire a 128x64 SSD1306 OLED: SDA->GPIO21, SCL->GPIO22, VCC->3V3, GND->GND.
+; ============================================================
+[env:esp32-devkit-oled]
+board = esp32dev
+board_build.partitions = huge_app.csv
+upload_speed = 921600
+
+build_unflags = -Os
+
+build_flags =
+    -D AUTO_VERSION=\"v2.9.5\"
+    -D ESP32_DEVKIT_OLED=1
+    ; Cosmetic on classic ESP32 (ASM SHA auto-selected via CONFIG_IDF_TARGET_ESP32)
+    -D USE_HARDWARE_SHA=1
+    -D USE_DISPLAY=0
+    -D USE_OLED_DISPLAY=1
+    ; OLED configuration (128x64 SSD1306 I2C, standard ESP32 pins)
+    ; NOTE: the driver reads OLED_SDA_PIN / OLED_SCL_PIN (display_oled.cpp), not OLED_I2C_*
+    -D OLED_WIDTH=128
+    -D OLED_HEIGHT=64
+    -D OLED_SDA_PIN=21
+    -D OLED_SCL_PIN=22
+    -D OLED_I2C_ADDR=0x3C
+    -D BUTTON_PIN=0
+    ; Optimization
+    -O3
+    -funroll-loops
+    ;-D DEBUG_MINING=1
+
+lib_deps =
+    ${env.lib_deps}
+    olikraus/U8g2@^2.35.9
+
+lib_ignore =
+    TFT_eSPI
+    OpenFontRender
+    SD
+    SD_MMC
+    FastLED


### PR DESCRIPTION
Adds an `esp32-devkit-oled` PlatformIO env, board_config block, devtool entry and README row for a plain ESP32 DevKit/WROOM driving a 128x64 SSD1306 I2C OLED (SDA=GPIO21, SCL=GPIO22, addr=0x3C).

- Purely additive — reuses the existing `USE_OLED_DISPLAY` driver path, no source changes.
- Classic ESP32 keeps the pipelined Xtensa ASM SHA (~715 KH/s) automatically.
- Uses the driver's real macro names (`OLED_SDA_PIN`/`OLED_SCL_PIN`) with `#ifndef` guards.

## ⚠️ Testing
- [ ] Compile + confirm OLED rendering on a real ESP32 DevKit + SSD1306.

Closes #26.