### PR TITLE
ci: add PlatformIO build workflow (ESP32 / S3 / C3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: build
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: build ${{ matrix.env }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Representative env per chip family (classic ESP32 / S3 / C3)
+        env: [esp32-2432s028, esp32-s3-devkit, esp32-c3-supermini]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: ~/.platformio
+          key: pio-${{ runner.os }}-${{ hashFiles('platformio.ini') }}
+          restore-keys: pio-${{ runner.os }}-
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Build ${{ matrix.env }}
+        run: pio run -e ${{ matrix.env }}


### PR DESCRIPTION
Adds `.github/workflows/build.yml` — builds one representative env per chip family (`esp32-2432s028`, `esp32-s3-devkit`, `esp32-c3-supermini`) on every PR and push to `main`, with PlatformIO core caching.

Once this has run green, it can be added as a **required status check** on the `main` ruleset so PRs can't merge unless they compile. Rebasing the open fix PRs (#36–#39) onto this will give them a compile check too.