### PR TITLE
Add SparkMiner support for the Heltec WiFi LoRa 32 V3 board.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Added
+- **Heltec WiFi LoRa 32 V3 support** - ESP32-S3 with 128x64 OLED, LoRa SX1262
+
 # Changelog
 
 All notable changes to SparkMiner will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Find your board below and download the matching firmware from [Releases](https:/
 | **Wemos/Lolin S3 Mini** | `esp32-s3-mini_firmware.bin` | RGB LED status indicator |
 | **WeAct S3 Mini** | `esp32-s3-mini_firmware.bin` | Compatible with Lolin |
 | **ESP32-S3 + SSD1306 OLED** | `esp32-s3-oled_firmware.bin` | 128x64 I2C OLED |
+| **Heltec WiFi LoRa 32 V3** | `heltec-wifi-lora32-v3_firmware.bin` | ESP32-S3, 128x64 OLED, LoRa SX1262 |
 
 ### ESP32-C3 Boards
 
@@ -179,6 +180,7 @@ Find your board below and download the matching firmware from [Releases](https:/
 | Wemos Lolin32 + OLED | ✅ Full | 128x64 SSD1306 I2C (SDA=GPIO5, SCL=GPIO4, RST=GPIO16, addr=0x3C) |
 | ESP32-S3/C3 Mini | ✅ Full | RGB LED status |
 | ESP32 Headless | ✅ Full | GPIO LED status indicator |
+| Heltec WiFi LoRa 32 V3 | ✅ Full | ESP32-S3, 128x64 OLED, LoRa SX1262 |
 | LILYGO T-Display S3 | ❌ None | Not yet supported |
 | LILYGO T-Display V1 | ❌ None | Not yet supported |
 | ESP32-S2 boards | ❌ None | Single-core not supported |

--- a/devtool.toml
+++ b/devtool.toml
@@ -156,6 +156,15 @@ description = "Wemos Lolin32 with SSD1306 OLED (SDA=GPIO5, SCL=GPIO4, RST=GPIO16
 needs_boot_mode = false
 group = "OLED Display"
 
+[boards.heltec-wifi-lora32-v3]
+name = "Heltec WiFi LoRa 32 V3"
+env = "heltec-wifi-lora32-v3"
+chip = "esp32s3"
+description = "Heltec WiFi LoRa 32 V3: ESP32-S3, 128x64 OLED (I2C), LoRa SX1262, no PSRAM (~280 H/s)"
+needs_boot_mode = true
+port_changes_on_reset = true
+group = "OLED Display"
+
 # ============================================================
 # Release Settings
 # ============================================================

--- a/include/board_config.h
+++ b/include/board_config.h
@@ -395,6 +395,36 @@
     // SHA Implementation: classic ESP32 hardware SHA peripheral
     // Defined in platformio.ini via -D USE_HARDWARE_SHA=1
 
+// Heltec WiFi LoRa 32 V3 - ESP32-S3, 128x64 OLED (I2C), LoRa SX1262
+// ============================================================
+#elif defined(HELTEC_V3)
+    #define BOARD_NAME "Heltec WiFi LoRa 32 V3"
+
+    // Use OLED display (not TFT)
+    #define USE_DISPLAY 0
+    #define USE_OLED_DISPLAY 1
+
+    // OLED configuration (128x64 SSD1306 I2C)
+    #define OLED_WIDTH 128
+    #define OLED_HEIGHT 64
+    #define OLED_SDA_PIN 17
+    #define OLED_SCL_PIN 18
+    #define OLED_I2C_ADDR 0x3C
+    #define OLED_RST_PIN 21
+
+    // Display power enable (Vext)
+    #define VEXT_PIN 36
+
+    // Onboard LED
+    #define LED_PIN 35
+
+    // Buttons
+    #define BUTTON_PIN 0      // BOOT
+    #define USER_BUTTON_PIN 14
+    #define BUTTON_ACTIVE_LOW 1
+
+    // SHA Implementation: Defined in platformio.ini (USE_HARDWARE_SHA=1)
+
 // ============================================================
 // Default - Generic ESP32
 // ============================================================

--- a/platformio.ini
+++ b/platformio.ini
@@ -734,6 +734,49 @@ lib_ignore =
     FastLED
 
 ; ============================================================
+; Heltec WiFi LoRa 32 V3 - ESP32-S3, 128x64 OLED (I2C), LoRa SX1262
+; Compatible with SparkMiner (SSD1306, U8g2, no PSRAM)
+; ============================================================
+[env:heltec-wifi-lora32-v3]
+board = heltec_wifi_lora_32_V3
+board_build.partitions = default_8MB.csv
+board_build.mcu = esp32s3
+board_build.f_cpu = 240000000L
+upload_speed = 921600
+
+build_unflags = -Os
+
+build_flags =
+    -D HELTEC_V3=1
+    -D USE_HARDWARE_SHA=1
+    -D USE_DISPLAY=0
+    -D USE_OLED_DISPLAY=1
+    -D OLED_WIDTH=128
+    -D OLED_HEIGHT=64
+    -D OLED_SDA_PIN=17
+    -D OLED_SCL_PIN=18
+    -D OLED_I2C_ADDR=0x3C
+    -D OLED_RST_PIN=21
+    -D VEXT_PIN=36
+    -D LED_PIN=35
+    -D BUTTON_PIN=0
+    -D USER_BUTTON_PIN=14
+    -O3
+    -funroll-loops
+    ;-D DEBUG_MINING=1
+
+lib_deps =
+    ${env.lib_deps}
+    olikraus/U8g2@^2.35.9
+
+lib_ignore =
+    TFT_eSPI
+    OpenFontRender
+    SD
+    SD_MMC
+    FastLED
+
+; ============================================================
 ; ESP32-S3 Headless - No display, serial only
 ; Dual-core with monochrome display and LoRa
 ; ============================================================

--- a/src/display/display_oled.cpp
+++ b/src/display/display_oled.cpp
@@ -216,10 +216,25 @@ static void drawStatsScreen(const display_data_t *data) {
 void oled_display_init(uint8_t rotation, uint8_t brightness) {
     Serial.printf("[OLED] Initializing %dx%d display\n", OLED_WIDTH, OLED_HEIGHT);
 
-    // Initialize I2C with custom pins
+
+#ifdef HELTEC_V3
+    Serial.println("HELTEC: Enabling Vext (GPIO36 LOW)");
+    pinMode(VEXT_PIN, OUTPUT);
+    digitalWrite(VEXT_PIN, LOW); // Vext ON (active low)
+    delay(50);
+
+    Serial.println("HELTEC: Resetting OLED (GPIO21)");
+    pinMode(OLED_RST_PIN, OUTPUT);
+    digitalWrite(OLED_RST_PIN, LOW);
+    delay(20);
+    digitalWrite(OLED_RST_PIN, HIGH);
+    delay(20);
+
+    Serial.println("HELTEC: Starting I2C (17,18)");
+#endif
     Wire.begin(OLED_SDA_PIN, OLED_SCL_PIN);
 
-    // Initialize U8g2
+    Serial.println("Initializing SSD1306 OLED with U8g2 library");
     s_u8g2.begin();
 
     // Set rotation
@@ -236,6 +251,9 @@ void oled_display_init(uint8_t rotation, uint8_t brightness) {
 
     // Show boot screen
     oled_display_show_boot();
+
+    pinMode(LED_PIN, OUTPUT);
+    digitalWrite(LED_PIN, LOW); // Off by default
 
     Serial.println("[OLED] Display initialized");
 }


### PR DESCRIPTION
## Summary

Add SparkMiner support for the Heltec WiFi LoRa 32 V3 board.

This introduces a new PlatformIO environment and board config for the ESP32-S3 based Heltec V3, including its onboard 128x64 SSD1306 OLED, Vext display power control, onboard LED, BOOT button, and user button wiring.

## Changes

- Add heltec-wifi-lora32-v3 PlatformIO environment
- Add HELTEC_V3 board configuration
- Configure OLED pins:
  - SDA: GPIO17
  - SCL: GPIO18
  - RST: GPIO21
  - I2C addr: 0x3C
- Enable Heltec Vext power before OLED init
- Add OLED reset handling during display initialization
- Add onboard LED and button definitions
- Register board in devtool.toml
- Document Heltec V3 in README supported boards table
- Add changelog entry

## Validation

Validated on Heltec WiFi LoRa 32 V3:

- Firmware builds with pio run -e heltec-wifi-lora32-v3
- Board boots successfully
- OLED initializes after Vext enable/reset sequence
- SparkMiner runs on ESP32-S3 with hardware SHA enabled
- Board is selectable through devtool metadata

## Notes

LoRa/SX1262 hardware is identified in the board metadata but is not used by SparkMiner in this change.