### PR TITLE
Fix miner/TLS hardware SHA collision (root cause of direct-HTTPS instability)

### DIFF
--- a/src/mining/miner.cpp
+++ b/src/mining/miner.cpp
@@ -11,6 +11,9 @@
 #include <Arduino.h>
 #include <esp_task_wdt.h>
 #include <ArduinoJson.h>
+#if defined(CONFIG_IDF_TARGET_ESP32)
+#include <sha/sha_parallel_engine.h>  // esp_sha_try_lock_engine (permanent claim)
+#endif
 
 #if defined(CONFIG_IDF_TARGET_ESP32)
 #include <soc/dport_reg.h>
@@ -397,6 +400,30 @@ void miner_init() {
     Serial.println("[MINER] Initialized (Hardware SHA-256 via direct register access)");
     Serial.println("[MINER] Dual-core hardware SHA sharing enabled");
 
+#if defined(CONFIG_IDF_TARGET_ESP32)
+    // Claim ALL SHA engine locks permanently on behalf of the mining
+    // assembly (which drives the SHA registers directly and never locks).
+    // mbedtls try-locks an engine and falls back to SOFTWARE when it's
+    // held - so TLS (direct HTTPS stats) can never touch the hardware
+    // mid-mine. Without this, a TLS hash interleaves with the pipelined
+    // assembly on the shared SHA_TEXT registers and both sides wedge:
+    // mining cores freeze in busy-waits and the TLS session hangs holding
+    // ~40KB heap (or trips the task WDT - the "HTTPS causes WDT crashes"
+    // that led to enableHttpsStats being disabled by default).
+    // ALL engines must be claimed, not just SHA-256: a TLS suite hashing
+    // with SHA-384 through a free engine corrupts the same registers.
+    // try-lock, not lock: SHA-384/512 share one lock and a blocking
+    // second acquisition deadlocks boot.
+    // Must run AFTER the self-tests above, which use mbedtls hardware SHA.
+    const esp_sha_type shaTypes[] = {SHA1, SHA2_256, SHA2_384, SHA2_512};
+    for (size_t i = 0; i < sizeof(shaTypes) / sizeof(shaTypes[0]); i++) {
+        bool claimed = esp_sha_try_lock_engine(shaTypes[i]);
+        Serial.printf("[MINER] HW SHA engine %d %s\n", (int)shaTypes[i],
+                      claimed ? "claimed for mining" : "already covered");
+    }
+    Serial.println("[MINER] TLS/mbedtls will fall back to software SHA");
+#endif
+
 #ifdef BENCHMARK_SHA_VERSIONS
     run_sha_benchmark();
 #endif
@@ -538,15 +565,10 @@ void miner_task_core0(void *param) {
             header_swapped[i] = __builtin_bswap32(header_words[i]);
         }
 
-        // Try to compute hardware midstate if we can grab the mutex
-        bool hasHwMidstate = false;
-        if (!s_core1HasSha && xSemaphoreTake(s_shaMutex, 0) == pdTRUE) {
-            sha256_ll_acquire();
-            sha256_ll_midstate(hw_midstate, (const uint8_t *)header_swapped);
-            sha256_ll_release();
-            xSemaphoreGive(s_shaMutex);
-            hasHwMidstate = true;
-        }
+        // NOTE: the old opportunistic hardware-midstate grab was removed.
+        // Its result was never used (the loop below is pure software), and
+        // with the SHA engine locks now held permanently for Core 1's
+        // assembly, sha256_ll_acquire() here would deadlock this task.
 
         while (s_miningActive) {
             // Pure software SHA - no hardware contention with Core 1

--- a/src/stats/live_stats.cpp
+++ b/src/stats/live_stats.cpp
@@ -14,6 +14,7 @@
 #include <HTTPClient.h>
 #include <ArduinoJson.h>
 #include <base64.h>
+#include <esp_task_wdt.h>
 #include "live_stats.h"
 #include "board_config.h"
 #include "../config/nvs_config.h"
@@ -412,36 +413,48 @@ static bool fetchViaProxy(const char *targetUrl, JsonDocument &doc) {
 }
 
 /**
- * Fetch URL directly via HTTPS (CPU intensive, may cause issues)
+ * Fetch URL directly via HTTPS (CPU intensive)
+ *
+ * The TLS handshake + read can occupy core 0 for tens of seconds
+ * (software SHA once the miner owns the hardware engines), starving the
+ * idle task and tripping the task watchdog. Unsubscribe core 0's idle
+ * task from the WDT for the duration of the fetch; mining on core 1
+ * stays watchdog-protected throughout.
  */
 static bool fetchHttpsDirect(const char *url, JsonDocument &doc) {
-    WiFiClientSecure secureClient;
-    secureClient.setInsecure();
-    secureClient.setTimeout(5000);
+    TaskHandle_t idle0 = xTaskGetIdleTaskHandleForCPU(0);
+    if (idle0) esp_task_wdt_delete(idle0);
 
-    HTTPClient http;
-    http.setUserAgent("SparkMiner/1.0 ESP32");
-    http.setTimeout(5000);
+    bool ok = false;
+    {
+        WiFiClientSecure secureClient;
+        secureClient.setInsecure();
+        secureClient.setTimeout(5000);
 
-    vTaskDelay(1);  // Yield before SSL handshake
+        HTTPClient http;
+        http.setUserAgent("SparkMiner/1.0 ESP32");
+        http.setTimeout(5000);
 
-    if (!http.begin(secureClient, url)) {
-        logError("HTTPS connect", -1);
-        return false;
+        vTaskDelay(1);  // Yield before SSL handshake
+
+        if (http.begin(secureClient, url)) {
+            int httpCode = http.GET();
+            if (httpCode == HTTP_CODE_OK) {
+                String payload = http.getString();
+                http.end();
+                DeserializationError err = deserializeJson(doc, payload);
+                ok = !err;
+            } else {
+                logError("HTTPS request", httpCode);
+                http.end();
+            }
+        } else {
+            logError("HTTPS connect", -1);
+        }
     }
 
-    int httpCode = http.GET();
-
-    if (httpCode == HTTP_CODE_OK) {
-        String payload = http.getString();
-        http.end();
-        DeserializationError err = deserializeJson(doc, payload);
-        return !err;
-    }
-
-    logError("HTTPS request", httpCode);
-    http.end();
-    return false;
+    if (idle0) esp_task_wdt_add(idle0);
+    return ok;
 }
 
 /**


### PR DESCRIPTION
## Symptoms

With `enableHttpsStats = true` on a classic ESP32 (CYD), the first direct-HTTPS stats fetch reliably destabilizes the device within a minute or two:

- both mining cores freeze (hash counters stop dead, hashrate falls to 0) with the stratum connection still "up"
- heap drops ~40KB and stays down (a wedged `WiFiClientSecure` session)
- or the task watchdog fires and reboots the device - I believe this is the "direct HTTPS may cause WDT crashes" that led to it being disabled by default

Some HTTPS servers also abort handshakes with a fatal alert even when the device *seems* fine (observed with pool.nerdminers.org, which negotiates a SHA-384 cipher suite - that turned out to be a clue, see below).

## Root cause

The ESP32 has one SHA peripheral whose parallel engines (SHA-1/256/384/512) **share the `SHA_TEXT` input registers**. The core-1 pipelined mining assembly drives those registers directly and never takes ESP-IDF's engine locks; mbedtls (TLS) hashes through the locked API and, finding the locks free, uses the same hardware. When the two interleave:

- the miner's in-flight block gets corrupted and the assembly wedges in the `SHA_BUSY` wait
- the TLS side's transcript hash is corrupted mid-handshake, so it hangs, or the server rejects the handshake with a fatal alert (any suite hashing with SHA-256 *or* SHA-384 - different engine lock, same shared registers)

## Fix

1. `miner_init()` permanently claims **all four** SHA engine locks on behalf of the mining assembly. mbedtls acquires engines with a *try-lock* and falls back to software SHA when they're held, so TLS can never touch the hardware mid-mine. Try-lock rather than lock, because SHA-384/512 share one lock and a blocking second acquisition deadlocks boot (found the hard way). This must run after the boot self-tests, which use mbedtls hardware SHA.
2. Core 0's opportunistic hardware-midstate grab is removed - its result was never used (the hybrid loop verifies/mines in software), and with the locks held permanently it would deadlock that task.
3. `fetchHttpsDirect()` unsubscribes core 0's **idle task** from the task WDT for the duration of the fetch: with TLS hashing in software on a chip that's also mining, a handshake can occupy core 0 long enough to starve IDLE0. Mining on core 1 stays watchdog-protected throughout.

## Verification

On an ESP32-2432S028R (CYD, the default env): repeated multi-minute soaks with direct HTTPS enabled - CoinGecko price + pool stats fetched every cycle, ~680 kH/s sustained with no dips, stable heap, zero WDT events, previously-failing SHA-384 handshakes now complete. Before the fix, the same configuration froze both mining cores within a minute of the first fetch.

With this in, `enableHttpsStats` could plausibly become safe to enable by default - happy to test further configurations if useful.

Companion PR: the block-height/fee fetches have a separate long-standing failure (HTTP to HTTPS redirect) fixed in #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
