### PR TITLE
Fix silently-broken block height and fee stats (mempool.space HTTP redirect)

### DIFF
--- a/src/stats/live_stats.cpp
+++ b/src/stats/live_stats.cpp
@@ -705,37 +705,24 @@ static void updatePrice() {
 }
 
 static void updateBlockHeight() {
-    // HTTP API - always works
-    WiFiClient client;
-    client.setTimeout(5000);
-
-    HTTPClient http;
-    http.setUserAgent("SparkMiner/1.0");
-    http.setTimeout(5000);
-
-    if (http.begin(client, API_BLOCK_HEIGHT)) {
-        int httpCode = http.GET();
-
-        if (httpCode == HTTP_CODE_OK) {
-            String payload = http.getString();
-            uint32_t height = payload.toInt();
-
-            if (height > 0) {
-                xSemaphoreTake(s_statsMutex, portMAX_DELAY);
-                s_stats.blockHeight = height;
-                s_stats.blockTimestamp = millis();
-                s_stats.blockValid = true;
-                xSemaphoreGive(s_statsMutex);
-            }
+    // The endpoint returns a bare number, which is a valid JSON document,
+    // so it can ride the shared fetchJson path (proxy or direct HTTPS)
+    s_jsonDoc.clear();
+    if (fetchJson(API_BLOCK_HEIGHT, s_jsonDoc)) {
+        uint32_t height = s_jsonDoc.as<uint32_t>();
+        if (height > 0) {
+            xSemaphoreTake(s_statsMutex, portMAX_DELAY);
+            s_stats.blockHeight = height;
+            s_stats.blockTimestamp = millis();
+            s_stats.blockValid = true;
+            xSemaphoreGive(s_statsMutex);
         }
-        http.end();
     }
 }
 
 static void updateFees() {
-    // HTTP API - always works
     s_jsonDoc.clear();
-    if (fetchHttp(API_FEES, s_jsonDoc)) {
+    if (fetchJson(API_FEES, s_jsonDoc)) {
         xSemaphoreTake(s_statsMutex, portMAX_DELAY);
         s_stats.fastestFee = s_jsonDoc["fastestFee"];
         s_stats.halfHourFee = s_jsonDoc["halfHourFee"];
@@ -779,9 +766,10 @@ static void updatePoolStats() {
 }
 
 static void updateNetworkHashrate() {
-    // Only fetch if HTTPS is available (proxy or direct)
-    if (!s_proxyConfigured && !s_httpsEnabled) return;
-    if (s_proxyConfigured && !s_proxyHealthy) return;
+    // This fetch is proxy-only: the raw socket below connects to the proxy
+    // host. Without a proxy it attempted a connect to an empty hostname
+    // ("[E] hostByName(): DNS Failed for" log spam) - bail out instead.
+    if (!s_proxyConfigured || !s_proxyHealthy) return;
 
     // The hashrate API returns ~400KB response with historical data.
     // We use a filter to extract only the fields we need, ignoring the "hashrates" array.

--- a/src/stats/live_stats.h
+++ b/src/stats/live_stats.h
@@ -23,11 +23,14 @@
 // API URLs
 // ============================================================
 
-// HTTP APIs (always used - no SSL overhead)
-#define API_BLOCK_HEIGHT    "http://mempool.space/api/blocks/tip/height"
+// NOTE: mempool.space 301-redirects HTTP to HTTPS and HTTPClient does not
+// follow it, so the plain-HTTP block-height and fee fetches have always
+// failed silently. Route them through the HTTPS path (proxy or direct)
+// like the other mempool endpoints.
+#define API_BLOCK_HEIGHT    "https://mempool.space/api/blocks/tip/height"
 #define API_HASHRATE        "https://mempool.space/api/v1/mining/hashrate/1d"
 #define API_DIFFICULTY      "https://mempool.space/api/v1/difficulty-adjustment"
-#define API_FEES            "http://mempool.space/api/v1/fees/recommended"
+#define API_FEES            "https://mempool.space/api/v1/fees/recommended"
 
 // HTTPS APIs (only used if proxy configured OR enableHttpsStats=true)
 #define API_BTC_PRICE       "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd"


### PR DESCRIPTION
## Symptoms

Block height and fees show `---`/`0` forever, on every board, regardless of config. The code comments say "HTTP API - always works", but these two fetches have never returned data.

## Root cause

mempool.space 301-redirects HTTP to HTTPS, and `HTTPClient` doesn't follow redirects — so the plain-HTTP `fetchHttp()`/raw-client paths get the redirect page's status and fail silently on every call.

Separately, `updateNetworkHashrate()` is proxy-only (it opens a raw socket to the proxy host), but its guard let direct-HTTPS mode fall through to `client.connect(s_proxyHost, ...)` with an empty hostname, producing repeated `[E] hostByName(): DNS Failed for` log spam.

## Fix

- Point `API_BLOCK_HEIGHT` and `API_FEES` at `https://` and route both through the shared `fetchJson()` path, which selects proxy or direct HTTPS per config. The block-height endpoint returns a bare number, which is a valid JSON document, so it parses through the same path — `updateBlockHeight()` loses its bespoke raw-client code.
- Require a healthy proxy in `updateNetworkHashrate()`.

## Behavior notes

With HTTPS disabled (the current default) these stats now skip cleanly instead of failing noisily — they were never being fetched anyway, so nothing regresses. With a proxy or direct HTTPS enabled, height and fees populate for the first time. Direct HTTPS itself is made stable by #43 (the SHA engine collision fix) — the two PRs are independent to merge but complementary in effect.

Verified on an ESP32-2432S028R with direct HTTPS enabled: height and fee values populate within the first stats cycle and refresh on schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
