### PR TITLE
fix(wifi): use data-ssid for scan-list autofill so SSIDs with spaces connect

### DIFF
--- a/src/config/wifi_manager.cpp
+++ b/src/config/wifi_manager.cpp
@@ -412,8 +412,19 @@ void wifi_manager_init() {
         "});"
         // Run sync after DOM is fully loaded
         "if(document.readyState==='loading'){document.addEventListener('DOMContentLoaded',syncDropdowns);}else{syncDropdowns();}"
-        // SSID auto-fill when clicking network link
-        "function c(l){console.log('[SSID] Clicked: '+l.innerText);var s=document.querySelector('input[name=\"s\"]');if(s){s.value=l.innerText||l.textContent;console.log('[SSID] Set to: '+s.value);}}"
+        // SSID auto-fill when clicking network link.
+        // Read data-ssid first: WiFiManager renders the *visible* link text with
+        // htmlEntities(ssid, true), which turns every space into &#160; (U+00A0
+        // non-breaking space). Using innerText therefore submits an SSID the
+        // ESP32 scan can never match, failing with reason 201 (NO_AP_FOUND) on
+        // any network whose name contains a space. data-ssid keeps real spaces.
+        "function c(l){"
+        "var s=document.querySelector('input[name=\"s\"]');"
+        "if(s){"
+        "var v=l.getAttribute('data-ssid')||l.innerText||l.textContent||'';"
+        "s.value=v.replace(/\\u00a0/g,' ');"  // normalize NBSP on fallback paths
+        "console.log('[SSID] Set to: '+JSON.stringify(s.value));"
+        "}}"
         "</script>";
     s_wm.setCustomHeadElement(customCSS);
 


### PR DESCRIPTION
## Problem

Picking a network from the config portal's scan list makes the device fail to join any AP whose name contains a space. It fails with disconnect reason `201` (`WIFI_REASON_NO_AP_FOUND`) even though the AP is present and the password is correct. Typing the same SSID by hand works — which makes this look like a router, signal, or credential problem rather than a portal bug.

## Root cause

`wifi_manager_init()` injects a custom `c(l)` handler through `setCustomHeadElement()` that fills the SSID field from `innerText`:

```js
function c(l){...s.value=l.innerText||l.textContent;...}
```

Since `_customHeadElement` is appended *after* the bundled `HTTP_SCRIPT`, this overrides WiFiManager's own `c()`.

WiFiManager renders each scan-list entry from `HTTP_ITEM`:

```
<div><a href='#p' onclick='c(this)' data-ssid='{V}'>{v}</a>...</div>
```

populating the two tokens differently:

```cpp
item.replace(FPSTR(T_V), htmlEntities(WiFi.SSID(i)));        // {V} -> data-ssid
item.replace(FPSTR(T_v), htmlEntities(WiFi.SSID(i), true));  // {v} -> visible text
```

and `htmlEntities(str, whitespace=true)` does `str.replace(" ", "&#160;")`.

So the **visible link text carries U+00A0** (non-breaking space) while **`data-ssid` keeps real `0x20` spaces**. Reading `innerText` submits `My<U+00A0>Network`, which never matches the real SSID during the scan — hence `NO_AP_FOUND` rather than an auth error.

This is precisely why WiFiManager's own handler reads `data-ssid` first.

## Fix

Read `data-ssid` first, falling back to `innerText`/`textContent` with U+00A0 normalized in case a future WiFiManager version drops the attribute.

## Testing

Verified on an ESP32-2432S028 (CYD, 2-USB) against a WPA2 network whose SSID contains a space:

- **Before:** clicking the network in the scan list produced repeated `[WIFI] Disconnected, reason: 201` and never associated.
- **After:** clicking the same network associates, gets a DHCP lease, and proceeds to stratum.
- Typing the SSID manually worked both before and after, since that path never invokes `c()`.

The portal code is shared, so this affects all boards.

## Notes

- Behaviour for manually-typed SSIDs is unchanged.
- The pre-existing override already dropped WiFiManager's `l.nextElementSibling` password-field enable/disable logic; this change keeps that as-is rather than widening scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)